### PR TITLE
Update SMD to OpenCHAMI version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,4 +52,4 @@ ct_image:
 	docker build --no-cache -f test/ct/Dockerfile test/ct/ --tag hms-bss-hmth-test:${VERSION}
 
 docker: $(BINARIES)
-	docker build --tag openchami/bss:$(VERSION)-dirty .
+	docker build --tag openchami/bss:v$(VERSION)-dirty .

--- a/docker-compose.bss-debugger.yaml
+++ b/docker-compose.bss-debugger.yaml
@@ -29,7 +29,7 @@ services:
       - smd
   smd-init:
     hostname: smd-init
-    image: bikeshack/smd:v2.12.11-ochami
+    image: ghcr.io/openchami/smd:v2.13.5
     environment:
       - SMD_DBHOST=postgres-smd
       - SMD_DBPORT=5432
@@ -44,7 +44,7 @@ services:
     command: ["/smd-init"]
   smd:
     hostname: smd
-    image: bikeshack/smd:v2.12.11-ochami
+    image: ghcr.io/openchami/smd:v2.13.5
     environment:
       - SMD_DBHOST=postgres-smd
       - SMD_DBPORT=5432

--- a/docker-compose.test.postgres.yaml
+++ b/docker-compose.test.postgres.yaml
@@ -29,7 +29,7 @@ services:
       - smd
   smd-init:
     hostname: smd-init
-    image: bikeshack/smd:v2.12.11-ochami
+    image: ghcr.io/openchami/smd:v2.13.5
     environment:
       - SMD_DBHOST=postgres-smd
       - SMD_DBPORT=5432
@@ -44,7 +44,7 @@ services:
     command: ["/smd-init"]
   smd:
     hostname: smd
-    image: bikeshack/smd:v2.12.11-ochami
+    image: ghcr.io/openchami/smd:v2.13.5
     environment:
       - SMD_DBHOST=postgres-smd
       - SMD_DBPORT=5432

--- a/test/ct/postgres/tests/mac/02-smd-get-components.hurl
+++ b/test/ct/postgres/tests/mac/02-smd-get-components.hurl
@@ -23,6 +23,6 @@ Content-Type: application/json
 jsonpath "$.Components[*].ID" includes "x0c0s1b0"
 jsonpath "$.Components[*].ID" includes "x0c0s3b0"
 jsonpath "$.Components[0].Type" == "Node"
-jsonpath "$.Components[0].Enabled" == false # This should be set to true eventually.
+jsonpath "$.Components[0].Enabled" == true
 jsonpath "$.Components[1].Type" == "Node"
-jsonpath "$.Components[1].Enabled" == false # This should be set to true eventually.
+jsonpath "$.Components[1].Enabled" == true

--- a/test/ct/postgres/tests/nid/02-smd-get-components.hurl
+++ b/test/ct/postgres/tests/nid/02-smd-get-components.hurl
@@ -23,6 +23,6 @@ Content-Type: application/json
 jsonpath "$.Components[*].ID" includes "x0c0s1b0"
 jsonpath "$.Components[*].ID" includes "x0c0s3b0"
 jsonpath "$.Components[0].Type" == "Node"
-jsonpath "$.Components[0].Enabled" == false # This should be set to true eventually.
+jsonpath "$.Components[0].Enabled" == true
 jsonpath "$.Components[1].Type" == "Node"
-jsonpath "$.Components[1].Enabled" == false # This should be set to true eventually.
+jsonpath "$.Components[1].Enabled" == true

--- a/test/ct/postgres/tests/xname/02-smd-get-components.hurl
+++ b/test/ct/postgres/tests/xname/02-smd-get-components.hurl
@@ -23,6 +23,6 @@ Content-Type: application/json
 jsonpath "$.Components[*].ID" includes "x0c0s1b0"
 jsonpath "$.Components[*].ID" includes "x0c0s3b0"
 jsonpath "$.Components[0].Type" == "Node"
-jsonpath "$.Components[0].Enabled" == false # This should be set to true eventually.
+jsonpath "$.Components[0].Enabled" == true
 jsonpath "$.Components[1].Type" == "Node"
-jsonpath "$.Components[1].Enabled" == false # This should be set to true eventually.
+jsonpath "$.Components[1].Enabled" == true


### PR DESCRIPTION
Update SMD in the docker-compose files to use the migrated OpenCHAMI version of SMD. Also, update the integration tests to work with the new version. Finally, fix the Docker version tag in the Makefile `docker` target (was missing the `v` version prefix).