### PR TITLE
Enable authentication by specifying JWKS URL instead of separate `--require-auth` flag

### DIFF
--- a/cmd/boot-script-service/routers.go
+++ b/cmd/boot-script-service/routers.go
@@ -93,7 +93,7 @@ func initHandlers() *chi.Mux {
 	router.Use(middleware.Recoverer)
 	router.Use(middleware.StripSlashes)
 	router.Use(middleware.Timeout(60 * time.Second))
-	if requireAuth {
+	if jwksURL != "" {
 		router.Group(func(r chi.Router) {
 			r.Use(
 				jwtauth.Verifier(tokenAuth),


### PR DESCRIPTION
Enable JWT authentication by specifying the JWKS URL (using the `BSS_JWKS_URL` environment variable or the `--jwks-url` flag) instead of having to have a separate `--require-auth` flag or a `BSS_REQUIRE_AUTH` environment variable.