### PR TITLE
Changed how BSS fetches a new token

### DIFF
--- a/cmd/boot-script-service/main.go
+++ b/cmd/boot-script-service/main.go
@@ -102,8 +102,8 @@ var (
 	jwksURL             = ""
 	sqlDbOpts           = ""
 	spireServiceURL     = "https://spire-tokens.spire:54440"
-	oauth2AdminBaseURL  = "http://127.0.0.1:4445"
-	oauth2PublicBaseURL = "http://127.0.0.1:4444"
+	oauth2AdminBaseURL  = "http://127.0.0.1:3333"
+	oauth2PublicBaseURL = "http://127.0.0.1:3333"
 )
 
 func parseEnv(evar string, v interface{}) (ret error) {

--- a/cmd/boot-script-service/main.go
+++ b/cmd/boot-script-service/main.go
@@ -453,7 +453,7 @@ func main() {
 	// try and fetch JWKS from issuer
 	if jwksURL != "" {
 		for i := uint64(0); i <= authRetryCount; i++ {
-			err := loadPublicKeyFromURL(jwksURL)
+			err := fetchPublicKey(jwksURL)
 			if err != nil {
 				log.Printf("failed to initialize auth token: %v", err)
 				time.Sleep(5 * time.Second)

--- a/cmd/boot-script-service/oauth.go
+++ b/cmd/boot-script-service/oauth.go
@@ -24,7 +24,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/go-chi/v5/jwtauth"
+	"github.com/go-chi/jwtauth/v5"
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/lestrrat-go/jwx/jwt"

--- a/cmd/boot-script-service/oauth.go
+++ b/cmd/boot-script-service/oauth.go
@@ -252,6 +252,9 @@ func JWTIsValid(jwtStr string) (jwtValid bool, reason, err error) {
 	return
 }
 
+// FetchAccessToken fetches an access token for this client (BSS).
+//
+// Returns the access token string necessary to supply for authorization requests.
 func (client *OAuthClient) FetchAccessToken(remoteUrl string) (string, error) {
 	// opaal endpoint: /token
 	headers := map[string][]string{

--- a/cmd/boot-script-service/oauth.go
+++ b/cmd/boot-script-service/oauth.go
@@ -55,6 +55,7 @@ func (nc nowClock) Now() time.Time {
 	return time.Now()
 }
 
+// fetchPublicKey fetches the JWKS (JSON Key Set) needed to verify JWTs with issuer.
 func fetchPublicKey(url string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cmd/boot-script-service/oauth.go
+++ b/cmd/boot-script-service/oauth.go
@@ -24,7 +24,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/go-chi/jwtauth"
+	"github.com/go-chi/v5/jwtauth"
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/lestrrat-go/jwx/jwt"

--- a/cmd/boot-script-service/oauth.go
+++ b/cmd/boot-script-service/oauth.go
@@ -176,7 +176,7 @@ func (client *OAuthClient) PollClientCreds(retryCount, retryInterval uint64) err
 	}
 	for i := uint64(0); i < retryCount; i++ {
 		log.Printf("Attempting to obtain access token (attempt %d/%d)", i+1, retryCount)
-		token, err := client.FetchAccessToken(oauth2AdminBaseURL)
+		token, err := client.FetchAccessToken(oauth2AdminBaseURL + "/token")
 		if err != nil {
 			log.Printf("Failed to obtain client credentials and token: %v", err)
 			time.Sleep(retryDuration)

--- a/cmd/boot-script-service/routers.go
+++ b/cmd/boot-script-service/routers.go
@@ -36,7 +36,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -45,8 +44,6 @@ import (
 	"github.com/go-chi/chi/middleware"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/jwtauth/v5"
-	"github.com/lestrrat-go/jwx/jwa"
-	"github.com/lestrrat-go/jwx/jwk"
 )
 
 const (

--- a/cmd/boot-script-service/routers.go
+++ b/cmd/boot-script-service/routers.go
@@ -62,29 +62,6 @@ var (
 	tokenAuth *jwtauth.JWTAuth
 )
 
-func loadPublicKeyFromURL(url string) error {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	set, err := jwk.Fetch(ctx, url)
-	if err != nil {
-		return fmt.Errorf("%v", err)
-	}
-	for it := set.Iterate(context.Background()); it.Next(context.Background()); {
-		pair := it.Pair()
-		key := pair.Value.(jwk.Key)
-
-		var rawkey interface{}
-		if err := key.Raw(&rawkey); err != nil {
-			continue
-		}
-
-		tokenAuth = jwtauth.New(jwa.RS256.String(), nil, rawkey)
-		return nil
-	}
-
-	return fmt.Errorf("failed to load public key: %v", err)
-}
-
 func initHandlers() *chi.Mux {
 	router := chi.NewRouter()
 	router.Use(middleware.RequestID)


### PR DESCRIPTION
This PR changes how BSS fetches an access token. It adds a single `FetchAccessToken` function that is used in place of the functions used to perform a client credentials grant. It also changes the `loadPublicKeyFromURL` function to `fetchPublicKey` and moves it to the `oauth.go` file.