### PR TITLE
Changed router/JWKS fetch order and use JWKSKeySet for verification

### DIFF
--- a/cmd/boot-script-service/main.go
+++ b/cmd/boot-script-service/main.go
@@ -448,8 +448,6 @@ func main() {
 	}
 	log.Printf("Service %s started", serviceName)
 
-	router := initHandlers()
-
 	// try and fetch JWKS from issuer
 	if jwksURL != "" {
 		for i := uint64(0); i <= authRetryCount; i++ {
@@ -463,6 +461,8 @@ func main() {
 			break
 		}
 	}
+
+	router := initHandlers()
 
 	var svcOpts string
 	if insecure {

--- a/cmd/boot-script-service/oauth.go
+++ b/cmd/boot-script-service/oauth.go
@@ -66,7 +66,7 @@ func fetchPublicKey(url string) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal JWKS: %v", err)
 	}
-	s.tokenAuth, err = jwtauth.NewKeySet(jwks)
+	tokenAuth, err = jwtauth.NewKeySet(jwks)
 	if err != nil {
 		return fmt.Errorf("failed to initialize JWKS: %v", err)
 	}

--- a/cmd/boot-script-service/oauth.go
+++ b/cmd/boot-script-service/oauth.go
@@ -24,8 +24,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/go-chi/jwtauth/v5"
-	"github.com/lestrrat-go/jwx/jwa"
+	"github.com/OpenCHAMI/jwtauth/v5"
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/lestrrat-go/jwx/jwt"
 )
@@ -63,17 +62,13 @@ func fetchPublicKey(url string) error {
 	if err != nil {
 		return fmt.Errorf("%v", err)
 	}
-	for it := set.Iterate(context.Background()); it.Next(context.Background()); {
-		pair := it.Pair()
-		key := pair.Value.(jwk.Key)
-
-		var rawkey interface{}
-		if err := key.Raw(&rawkey); err != nil {
-			continue
-		}
-
-		tokenAuth = jwtauth.New(jwa.RS256.String(), nil, rawkey)
-		return nil
+	jwks, err := json.Marshal(set)
+	if err != nil {
+		return fmt.Errorf("failed to marshal JWKS: %v", err)
+	}
+	s.tokenAuth, err = jwtauth.NewKeySet(jwks)
+	if err != nil {
+		return fmt.Errorf("failed to initialize JWKS: %v", err)
 	}
 
 	return fmt.Errorf("failed to load public key: %v", err)

--- a/cmd/boot-script-service/routers.go
+++ b/cmd/boot-script-service/routers.go
@@ -41,9 +41,9 @@ import (
 	"time"
 
 	base "github.com/Cray-HPE/hms-base"
+	"github.com/OpenCHAMI/jwtauth/v5"
 	"github.com/go-chi/chi/middleware"
 	"github.com/go-chi/chi/v5"
-	"github.com/go-chi/jwtauth/v5"
 )
 
 const (


### PR DESCRIPTION
This PR address #31 by fetching the JWKS before initializing the router. This should make it so the healthy endpoint is only available after BSS has gotten a valid key.