### PR TITLE
Multi-arch builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,9 +14,9 @@ builds:
     goos:
       - linux
     goarch:
-      - amd64
       - arm64
-    no_unique_dist_dir: true
+      - amd64
+    no_unique_dist_dir: false
     tags:
       - dynamic
   - id: bss-init
@@ -27,29 +27,69 @@ builds:
     goarch:
       - amd64
       - arm64
-    no_unique_dist_dir: true
+    no_unique_dist_dir: false
     tags:
       - dynamic
 
 dockers:
-  - 
-    image_templates:
-      - ghcr.io/openchami/{{.ProjectName}}:latest
-      - ghcr.io/openchami/{{.ProjectName}}:{{ .Tag }}
-      - ghcr.io/openchami/{{.ProjectName}}:{{ .Major }}
-      - ghcr.io/openchami/{{.ProjectName}}:{{ .Major }}.{{ .Minor }}
+  - image_templates:
+      - ghcr.io/openchami/{{.ProjectName}}:latest-amd64
+      - ghcr.io/openchami/{{.ProjectName}}:{{ .Tag }}-amd64
+      - ghcr.io/openchami/{{.ProjectName}}:{{ .Major }}-amd64
+      - ghcr.io/openchami/{{.ProjectName}}:{{ .Major }}.{{ .Minor }}-amd64
     build_flag_templates:
       - "--pull"
+      - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
+    goarch: amd64
+    use: buildx
     extra_files:
       - LICENSE
       - CHANGELOG.md
       - README.md
       - .version
       - migrations/
+  - image_templates:
+      - ghcr.io/openchami/{{.ProjectName}}:latest-arm64
+      - ghcr.io/openchami/{{.ProjectName}}:{{ .Tag }}-arm64
+      - ghcr.io/openchami/{{.ProjectName}}:{{ .Major }}-arm64
+      - ghcr.io/openchami/{{.ProjectName}}:{{ .Major }}.{{ .Minor }}-arm64
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+    goarch: arm64
+    use: buildx
+    extra_files:
+      - LICENSE
+      - CHANGELOG.md
+      - README.md
+      - .version
+      - migrations/
+
+docker_manifests:
+- name_template: 'ghcr.io/openchami/{{.ProjectName}}:latest'
+  image_templates:
+  - 'ghcr.io/openchami/{{.ProjectName}}:latest-amd64'
+  - 'ghcr.io/openchami/{{.ProjectName}}:latest-arm64'
+- name_template: 'ghcr.io/openchami/{{.ProjectName}}:{{ .Tag }}'
+  image_templates:
+  - 'ghcr.io/openchami/{{.ProjectName}}:{{ .Tag }}-amd64'
+  - 'ghcr.io/openchami/{{.ProjectName}}:{{ .Tag }}-arm64'
+- name_template: 'ghcr.io/openchami/{{.ProjectName}}:{{ .Major }}'
+  image_templates:
+  - 'ghcr.io/openchami/{{.ProjectName}}:{{ .Major }}-amd64'
+  - 'ghcr.io/openchami/{{.ProjectName}}:{{ .Major }}-arm64'
+- name_template: 'ghcr.io/openchami/{{.ProjectName}}:{{ .Major }}.{{ .Minor }}'
+  image_templates:
+  - 'ghcr.io/openchami/{{.ProjectName}}:{{ .Major }}.{{ .Minor }}-amd64'
+  - 'ghcr.io/openchami/{{.ProjectName}}:{{ .Major }}.{{ .Minor }}-arm64'
 
 archives:
   - format: tar.gz
@@ -66,7 +106,6 @@ archives:
       - CHANGELOG.md
       - README.md
 
-
 checksum:
   name_template: 'checksums.txt'
 snapshot:
@@ -77,7 +116,6 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
-
 
 # The lines beneath this are called `modelines`. See `:help modeline`
 # Feel free to remove those if you don't want/use them.


### PR DESCRIPTION
update to .goreleaser.yaml to build arm64 and amd64 images, then create/push the manifest.