### PR TITLE
Routers: implement POST notification for bootscript requests

### DIFF
--- a/cmd/boot-script-service/main.go
+++ b/cmd/boot-script-service/main.go
@@ -104,6 +104,7 @@ var (
 	spireServiceURL     = "https://spire-tokens.spire:54440"
 	oauth2AdminBaseURL  = "http://127.0.0.1:3333"
 	oauth2PublicBaseURL = "http://127.0.0.1:3333"
+	bootscriptNotifyURL = ""
 )
 
 func parseEnv(evar string, v interface{}) (ret error) {
@@ -324,6 +325,10 @@ func parseEnvVars() error {
 	if parseErr != nil {
 		errList = append(errList, fmt.Errorf("BSS_OAUTH2_PUBLIC_BASE_URL: %q", parseErr))
 	}
+	parseErr = parseEnv("BSS_BOOTSCRIPT_NOTIFY_URL", &bootscriptNotifyURL)
+	if parseErr != nil {
+		errList = append(errList, fmt.Errorf("BSS_BOOTSCRIPT_NOTIFY_URL: %q", parseErr))
+	}
 
 	//
 	// Etcd environment variables
@@ -421,6 +426,7 @@ func parseCmdLine() {
 	flag.StringVar(&jwksURL, "jwks-url", jwksURL, "(BSS_JWKS_URL) Set the JWKS URL to fetch the public key for authorization (enables authentication)")
 	flag.StringVar(&oauth2AdminBaseURL, "oauth2-admin-base-url", oauth2AdminBaseURL, "(BSS_OAUTH2_ADMIN_BASE_URL) Base URL of the OAUTH2 server admin endpoints for client authorizations")
 	flag.StringVar(&oauth2PublicBaseURL, "oauth2-public-base-url", oauth2PublicBaseURL, "(BSS_OAUTH2_PUBLIC_BASE_URL) Base URL of the OAUTH2 server public endpoints (e.g. for token grants)")
+	flag.StringVar(&bootscriptNotifyURL, "bootscript-notify-url", bootscriptNotifyURL, "(BSS_BOOTSCRIPT_NOTIFY_URL) Full URL to which newly-booted node IPs should be POSTed (e.g. TPM-manager server)")
 	flag.BoolVar(&insecure, "insecure", insecure, "(BSS_INSECURE) Don't enforce https certificate security")
 	flag.BoolVar(&debugFlag, "debug", debugFlag, "(BSS_DEBUG) Enable debug output")
 	flag.BoolVar(&useSQL, "postgres", useSQL, "(BSS_USESQL) Use Postgres instead of ETCD")

--- a/cmd/boot-script-service/routers.go
+++ b/cmd/boot-script-service/routers.go
@@ -37,6 +37,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	net_url "net/url"
 	"time"
@@ -45,6 +46,7 @@ import (
 	"github.com/OpenCHAMI/jwtauth/v5"
 	"github.com/go-chi/chi/middleware"
 	"github.com/go-chi/chi/v5"
+	"github.com/hashicorp/go-retryablehttp"
 )
 
 const (
@@ -217,9 +219,9 @@ func endpointHistoryGet(w http.ResponseWriter, r *http.Request) {
 }
 
 func notifyTarget(url string, data string) {
-	resp, err := http.PostForm(url, net_url.Values{"data": {data}})
+	resp, err := retryablehttp.PostForm(url, net_url.Values{"data": {data}})
 	if err != nil {
-		fmt.Printf("Error POSTing to %s: %v\n", url, err)
+		log.Printf("WARNING: HTTP POST failed: %v\n", err)
 		return
 	}
 	defer resp.Body.Close()

--- a/cmd/boot-script-service/routers.go
+++ b/cmd/boot-script-service/routers.go
@@ -38,6 +38,7 @@ package main
 import (
 	"fmt"
 	"net/http"
+	net_url "net/url"
 	"time"
 
 	base "github.com/Cray-HPE/hms-base"
@@ -130,6 +131,9 @@ func bootParameters(w http.ResponseWriter, r *http.Request) {
 }
 
 func bootScript(w http.ResponseWriter, r *http.Request) {
+	if bootscriptNotifyURL != "" {
+		go notifyTarget(bootscriptNotifyURL, r.RemoteAddr)
+	}
 	switch r.Method {
 	case http.MethodGet:
 		BootscriptGet(w, r)
@@ -210,4 +214,13 @@ func endpointHistoryGet(w http.ResponseWriter, r *http.Request) {
 	default:
 		sendAllowable(w, "GET")
 	}
+}
+
+func notifyTarget(url string, data string) {
+	resp, err := http.PostForm(url, net_url.Values{"data": {data}})
+	if err != nil {
+		fmt.Printf("Error POSTing to %s: %v\n", url, err)
+		return
+	}
+	defer resp.Body.Close()
 }

--- a/cmd/boot-script-service/routers.go
+++ b/cmd/boot-script-service/routers.go
@@ -221,7 +221,7 @@ func endpointHistoryGet(w http.ResponseWriter, r *http.Request) {
 func notifyTarget(url string, data string) {
 	resp, err := retryablehttp.PostForm(url, net_url.Values{"data": {data}})
 	if err != nil {
-		log.Printf("WARNING: HTTP POST failed: %v\n", err)
+		log.Printf("WARNING: HTTP POST of \"%v\" failed: %v\n", data, err)
 		return
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
This PR:
- Adds a generic HTTP(S) notifier function, which can be invoked to POST form data to an arbitrary endpoint
- Implements the ability to, whenever a node that requests its bootscript, POST that node's IP address to a configurable endpoint (i.e. indicating that the given node will soon require configuration)
  - The endpoint POSTed to is configurable via a CLI parameter (and associated environment variable)

This is to be used with the new TPM-manager OCHAMI component, specifically to inform the TPM manager when a new node is booting and will soon be ready to receive its TPM secret.

Implemented with help from @davidallendj