### PR TITLE
Fixed incorrect error returned from fetchPublicKey()

### DIFF
--- a/cmd/boot-script-service/oauth.go
+++ b/cmd/boot-script-service/oauth.go
@@ -71,7 +71,8 @@ func fetchPublicKey(url string) error {
 		return fmt.Errorf("failed to initialize JWKS: %v", err)
 	}
 
-	return fmt.Errorf("failed to load public key: %v", err)
+	// no errors occurred up to this point, so everything is fine here
+	return nil
 }
 
 func (client *OAuthClient) CreateOAuthClient(registerUrl string) ([]byte, error) {


### PR DESCRIPTION
The `fetchPublicKey()` function is currently returning an error although everything is working correctly. This will show up in the logs although the error itself is `<nil>`. This PR fixes the issue by having the function return `<nil>` instead of an error message.