### PR TITLE
return nil at the end of fetchPublicKey

### DIFF
--- a/cmd/boot-script-service/oauth.go
+++ b/cmd/boot-script-service/oauth.go
@@ -71,7 +71,7 @@ func fetchPublicKey(url string) error {
 		return fmt.Errorf("failed to initialize JWKS: %v", err)
 	}
 
-	return fmt.Errorf("failed to load public key: %v", err)
+	return nil
 }
 
 func (client *OAuthClient) CreateOAuthClient(registerUrl string) ([]byte, error) {


### PR DESCRIPTION
`fetchPublicKey` always returns a "failed to load public key" error even if err is nil.

Just changed:  
```
return fmt.Errorf("failed to load public key: %v", err)
```
to 
```
return nil
```