### PR TITLE
Add input checking for MAC addresses

### DIFF
--- a/cmd/boot-script-service/default_api.go
+++ b/cmd/boot-script-service/default_api.go
@@ -476,6 +476,15 @@ func BootparametersPut(w http.ResponseWriter, r *http.Request) {
 			fmt.Sprintf("Bad Request: %s", err))
 		return
 	}
+	// Check that MAC address(es) is/are valid format
+	err = args.CheckMacs()
+	if err != nil {
+		// Invalid MAC address format (if included), invalid request
+		LogBootParameters(fmt.Sprintf("/bootparameters PUT FAILED: %s", err.Error()), args)
+		base.SendProblemDetailsGeneric(w, http.StatusBadRequest,
+			fmt.Sprintf("Bad Request: %s", err))
+		return
+	}
 	debugf("Received boot parameters: %v\n", args)
 	err, referralToken := Store(args)
 	if err == nil {
@@ -503,6 +512,15 @@ func BootparametersPatch(w http.ResponseWriter, r *http.Request) {
 	err := dec.Decode(&args)
 	if err != nil {
 		debugf("BootparametersPatch: Bad Request: %v\n", err)
+		base.SendProblemDetailsGeneric(w, http.StatusBadRequest,
+			fmt.Sprintf("Bad Request: %s", err))
+		return
+	}
+	// Check that MAC address(es) is/are valid format
+	err = args.CheckMacs()
+	if err != nil {
+		// Invalid MAC address format (if included), invalid request
+		LogBootParameters(fmt.Sprintf("/bootparameters PATCH FAILED: %s", err.Error()), args)
 		base.SendProblemDetailsGeneric(w, http.StatusBadRequest,
 			fmt.Sprintf("Bad Request: %s", err))
 		return

--- a/cmd/boot-script-service/default_api.go
+++ b/cmd/boot-script-service/default_api.go
@@ -440,6 +440,15 @@ func BootparametersPost(w http.ResponseWriter, r *http.Request) {
 			fmt.Sprintf("Bad Request: %s", err))
 		return
 	}
+	// Check that MAC address(es) is/are valid format
+	err = args.CheckMacs()
+	if err != nil {
+		// Invalid MAC address format (if included), invalid request
+		LogBootParameters(fmt.Sprintf("/bootparameters POST FAILED: %s", err.Error()), args)
+		base.SendProblemDetailsGeneric(w, http.StatusBadRequest,
+			fmt.Sprintf("Bad Request: %s", err))
+		return
+	}
 	debugf("Received boot parameters: %v\n", args)
 	err, referralToken := StoreNew(args)
 	if err == nil {

--- a/pkg/bssTypes/types.go
+++ b/pkg/bssTypes/types.go
@@ -22,6 +22,11 @@
 
 package bssTypes
 
+import (
+	"fmt"
+	"regexp"
+)
+
 type PhoneHome struct {
 	PublicKeyDSA     string `form:"pub_key_dsa" json:"pub_key_dsa" binding:"omitempty"`
 	PublicKeyRSA     string `form:"pub_key_rsa" json:"pub_key_rsa" binding:"omitempty"`
@@ -58,6 +63,21 @@ type BootParams struct {
 	Kernel    string    `json:"kernel,omitempty"`
 	Initrd    string    `json:"initrd,omitempty"`
 	CloudInit CloudInit `json:"cloud-init,omitempty"`
+}
+
+func (bp BootParams) CheckMacs() (err error) {
+	if len(bp.Macs) > 0 {
+		re := regexp.MustCompile(`^([0-9A-Fa-f]{2}:){5}[0-9a-fA-F]{2}$`)
+		for _, mac := range bp.Macs {
+			// If MAC is incorrectly formatted, return error
+			if valid := re.MatchString(mac); !valid {
+				return fmt.Errorf("invalid MAC address format: %s\n", mac)
+			}
+		}
+	}
+
+	// All MACs are correctly format, return nil error
+	return
 }
 
 // The following structures and types all related to the last access information for bootscripts and cloud-init data.


### PR DESCRIPTION
Fixes #37.

Adds a `CheckMacs()` method to the `BootParams` struct in the bssTypes module. This function ensures that each MAC address in a BootParams payload passed in a POST, PUT, or PATCH request matches the regular expression `^([0-9A-Fa-f]{2}:){5}[0-9a-fA-F]{2}$` (upper or lower case MAC address separated by colons). If any in the list do not match, a 400 Bad Request is returned with the message `Bad Request: invalid MAC address format: <bad-mac-address>`. If either all MAC addresses in the list pass the check or no MAC addresses were passed at all, the check passes and the request is processed further.