### PR TITLE
Switch out /service/etcd service endpoint for /service/storage/status to support multiple backends

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -628,39 +628,59 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/Error'
-  /boot/v1/service/etcd:
+  /boot/v1/service/data:
     get:
-      summary: "Retrieve the current connection status to ETCD"
+      summary: "Retrieve the current connection status to storage backend"
       tags:
       - service-status
       - cli_ignore
       description: |
-        Retrieve the current connection status to the BSS ETCD database.
+        Retrieve the current connection status to the BSS backend storage database. This can
+        either be ETCD or PostgreSQL, depending on which storage backend BSS was started with.
         
-        The connection to ETCD will be tested by writing a value to ETCD, and then reading it
-        back from the database. If the value is successfully writen to ETCD and read back as the 
-        same value, then the connection to ETCD is considered to be connected. Otherwise, there
-        is a connection error.
+        If PostgreSQL is being used, the connection will be tested by attempting to retrieve all
+        of the boot parameters that BSS knows about. If this succeeds (even if the result is
+        empty), then the connection to PostgreSQL is considered to be connected. If this fails,
+        there is a connection error.
+
+        If ETCD is being used, the connection will be tested by writing a value to ETCD, and then
+        reading it back from the database. If the value is successfully writen to ETCD and read
+        back as the same value, then the connection to ETCD is considered to be connected.
+        Otherwise, there is a connection error.
         
       responses:
         '200':
-          description: 'The ETCD database connection is healthy.'
+          description: 'The connection to the storage backend is healthy.'
           schema:
             type: object
             properties:
-              bss-status-etcd:
-                type: string
-                enum: ["connected"]
-                description: Current connection status to ETCD.
+              bss-storage-backend:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    enum: ["etcd","postgres"]
+                    description: 'Name of the storage backend.'
+                  status:
+                    type: string
+                    enum: ["connected"]
+                    description: 'Current connection status to the storage backend.'
         '500':
-          description: 'The ETCD database connection is unhealthy.'
+          description: 'The connection to the storage backend is unhealthy.'
           schema:
             type: object
             properties:
-              bss-status-etcd:
-                type: string
-                enum: ["error"]
-                description: Current connection status to ETCD.
+              bss-storage-backend:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    enum: ["etcd","postgres"]
+                    description: 'Name of the storage backend.'
+                  status:
+                    type: string
+                    enum: ["error"]
+                    description: 'Current connection status to the storage backend.'
             
   /boot/v1/service/hsm:
     get:
@@ -743,10 +763,10 @@ paths:
               bss-status:
                 type: string
                 enum: ["running"]
-              bss-status-etcd:
+              bss-status-storage-backend:
                 type: string
                 enum: ["connected"]
-                description: Current connection status to ETCD.
+                description: Current connection status to storage backend.
               bss-status-hsm:
                 type: string
                 enum: ["connected"]
@@ -763,7 +783,7 @@ paths:
               bss-status:
                 type: string
                 enum: ["running"]
-              bss-status-etcd:
+              bss-status-storage-backend:
                 type: string
                 enum: ["connected", "error"]
                 description: Current connection status to ETCD.

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -644,7 +644,7 @@ paths:
         there is a connection error.
 
         If ETCD is being used, the connection will be tested by writing a value to ETCD, and then
-        reading it back from the database. If the value is successfully writen to ETCD and read
+        reading it back from the database. If the value is successfully written to ETCD and read
         back as the same value, then the connection to ETCD is considered to be connected.
         Otherwise, there is a connection error.
         

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -628,7 +628,7 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/Error'
-  /boot/v1/service/data:
+  /boot/v1/service/storage/status:
     get:
       summary: "Retrieve the current connection status to storage backend"
       tags:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -763,10 +763,17 @@ paths:
               bss-status:
                 type: string
                 enum: ["running"]
-              bss-status-storage-backend:
-                type: string
-                enum: ["connected"]
-                description: Current connection status to storage backend.
+              bss-storage-backend:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    enum: ["etcd","postgres"]
+                    description: 'Name of the storage backend.'
+                  status:
+                    type: string
+                    enum: ["connected"]
+                    description: 'Current connection status to the storage backend.'
               bss-status-hsm:
                 type: string
                 enum: ["connected"]
@@ -783,11 +790,17 @@ paths:
               bss-status:
                 type: string
                 enum: ["running"]
-              bss-status-storage-backend:
-                type: string
-                enum: ["connected", "error"]
-                description: Current connection status to ETCD.
-                example: "error"
+              bss-storage-backend:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    enum: ["etcd","postgres"]
+                    description: 'Name of the storage backend.'
+                  status:
+                    type: string
+                    enum: ["error"]
+                    description: 'Current connection status to the storage backend.'
               bss-status-hsm:
                 type: string
                 enum: ["connected", "error"]

--- a/cmd/boot-script-service/routers.go
+++ b/cmd/boot-script-service/routers.go
@@ -91,6 +91,7 @@ func initHandlers() *chi.Mux {
 	router.HandleFunc(baseEndpoint+"/bootscript", bootScript)
 	router.HandleFunc(baseEndpoint+"/hosts", hosts)
 	router.HandleFunc(baseEndpoint+"/dumpstate", dumpstate)
+	router.HandleFunc(baseEndpoint+"/service/all", service)
 	router.HandleFunc(baseEndpoint+"/service/status", serviceStatusResponse)
 	router.HandleFunc(baseEndpoint+"/service/version", serviceVersionResponse)
 	router.HandleFunc(baseEndpoint+"/service/hsm", serviceHSMResponse)

--- a/cmd/boot-script-service/routers.go
+++ b/cmd/boot-script-service/routers.go
@@ -94,7 +94,7 @@ func initHandlers() *chi.Mux {
 	router.HandleFunc(baseEndpoint+"/service/status", serviceStatusResponse)
 	router.HandleFunc(baseEndpoint+"/service/version", serviceVersionResponse)
 	router.HandleFunc(baseEndpoint+"/service/hsm", serviceHSMResponse)
-	router.HandleFunc(baseEndpoint+"/service/etcd", serviceETCDResponse)
+	router.HandleFunc(baseEndpoint+"/service/data", serviceDataResponse)
 	// cloud-init
 	router.HandleFunc(metaDataRoute, metaDataGet)
 	router.HandleFunc(userDataRoute, userDataGet)

--- a/cmd/boot-script-service/routers.go
+++ b/cmd/boot-script-service/routers.go
@@ -94,7 +94,7 @@ func initHandlers() *chi.Mux {
 	router.HandleFunc(baseEndpoint+"/service/status", serviceStatusResponse)
 	router.HandleFunc(baseEndpoint+"/service/version", serviceVersionResponse)
 	router.HandleFunc(baseEndpoint+"/service/hsm", serviceHSMResponse)
-	router.HandleFunc(baseEndpoint+"/service/data", serviceDataResponse)
+	router.HandleFunc(baseEndpoint+"/service/storage/status", serviceStorageResponse)
 	// cloud-init
 	router.HandleFunc(metaDataRoute, metaDataGet)
 	router.HandleFunc(userDataRoute, userDataGet)

--- a/cmd/boot-script-service/serviceAPI.go
+++ b/cmd/boot-script-service/serviceAPI.go
@@ -91,10 +91,10 @@ func serviceStatusAPI(w http.ResponseWriter, req *http.Request) {
 
 			if bp, err := bssdb.GetBootParamsAll(); err != nil {
 				httpStatus = http.StatusInternalServerError
-				log.Printf("Test access to postgres failed: BootParamsGetAll(): %v", err)
+				log.Printf("Test access to postgres failed: %v", err)
 				bssStatus.StorageBackend.Status = "error"
 			} else {
-				log.Println("Test access to postgres using BootParamsGetAll() succeeded")
+				log.Println("Test access to postgres using postgres.BootParamsGetAll() succeeded")
 				debugf("Boot parameters returned: %v", bp)
 			}
 		} else {
@@ -194,7 +194,7 @@ func serviceDataResponse(w http.ResponseWriter, req *http.Request) {
 
 		if bp, err := bssdb.GetBootParamsAll(); err != nil {
 			httpStatus = http.StatusInternalServerError
-			log.Printf("Test access to postgres failed: BootParamsGetAll(): %v", err)
+			log.Printf("Test access to postgres failed: %v", err)
 			bssStatus.StorageBackend.Status = "error"
 		} else {
 			log.Println("Test access to postgres using BootParamsGetAll() succeeded")

--- a/cmd/boot-script-service/serviceAPI.go
+++ b/cmd/boot-script-service/serviceAPI.go
@@ -108,14 +108,14 @@ func serviceStatusAPI(w http.ResponseWriter, req *http.Request) {
 			if err != nil {
 				httpStatus = http.StatusInternalServerError
 				sb.Status = "error"
-				log.Printf("Test store to etcd failed: %s", err)
+				log.Printf("Test store to etcd failed: %v", err)
 			} else {
 				ret, err := etcdTestGet()
 				if err != nil || ret != randnum {
 					httpStatus = http.StatusInternalServerError
 					sb.Status = "error"
 					if err != nil {
-						log.Printf("Test read from etcd failed: %s", err)
+						log.Printf("Test read from etcd failed: %v", err)
 					} else {
 						log.Printf("Test read from etcd miscompare: Expected %d, Actual %d", randnum, ret)
 					}
@@ -149,7 +149,7 @@ func serviceVersionResponse(w http.ResponseWriter, req *http.Request) {
 		if err != nil {
 			httpStatus = http.StatusInternalServerError
 			dat = []byte("error")
-			log.Printf("Cannot read version file: %s", err)
+			log.Printf("Cannot read version file: %v", err)
 		}
 	}
 	bssStatus.Version = strings.TrimSpace(string(dat))
@@ -169,7 +169,7 @@ func serviceHSMResponse(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		httpStatus = http.StatusInternalServerError
 		bssStatus.HSMStatus = "error"
-		log.Printf("Cannot connect to HSM: %s", err)
+		log.Printf("Cannot connect to HSM: %v", err)
 	} else {
 		_, err = ioutil.ReadAll(rsp.Body)
 		if err != nil {

--- a/cmd/boot-script-service/serviceAPI.go
+++ b/cmd/boot-script-service/serviceAPI.go
@@ -40,8 +40,8 @@ type serviceStatus struct {
 }
 
 type storageBackend struct {
-	Name   string `json:"name"`
-	Status string `json:"status"`
+	Name   string `json:"name",omitempty`
+	Status string `json:"status",omitempty`
 }
 
 func serviceStatusAPI(w http.ResponseWriter, req *http.Request) {

--- a/cmd/boot-script-service/serviceAPI.go
+++ b/cmd/boot-script-service/serviceAPI.go
@@ -97,7 +97,7 @@ func serviceStatusAPI(w http.ResponseWriter, req *http.Request) {
 				log.Printf("Test access to postgres failed: %v", err)
 				sb.Status = "error"
 			} else {
-				log.Println("Test access to postgres using postgres.BootParamsGetAll() succeeded")
+				log.Println("Test access to postgres using postgres.GetBootParamsAll() succeeded")
 				debugf("Boot parameters returned: %v", bp)
 			}
 		} else {

--- a/cmd/boot-script-service/serviceAPI.go
+++ b/cmd/boot-script-service/serviceAPI.go
@@ -83,7 +83,8 @@ func serviceStatusAPI(w http.ResponseWriter, req *http.Request) {
 			rsp.Body.Close()
 		}
 	}
-	if strings.Contains(strings.ToUpper(req.URL.Path), "DATA") ||
+	if strings.Contains(strings.ToUpper(req.URL.Path), "STORAGE") &&
+		strings.Contains(strings.ToUpper(req.URL.Path), "STATUS") ||
 		strings.Contains(strings.ToUpper(req.URL.Path), "ALL") {
 		var sb storageBackend
 		bssStatus.StorageBackend = &sb
@@ -184,7 +185,7 @@ func serviceHSMResponse(w http.ResponseWriter, req *http.Request) {
 	fmt.Fprintln(w, string(out))
 }
 
-func serviceDataResponse(w http.ResponseWriter, req *http.Request) {
+func serviceStorageResponse(w http.ResponseWriter, req *http.Request) {
 	var (
 		bssStatus  serviceStatus
 		httpStatus = http.StatusOK


### PR DESCRIPTION
Introduces one of multiple fixes for #20.

BSS used to support only the EtcD backend, so having a `/service/etcd` endpoint made sense. However, with the recent support of a PostgreSQL backend, it makes more sense to make this more generic.

This endpoint is now changed to ~~`/data`~~`/service/storage/status`, and the response JSON now includes which backend is being used (i.e. "etcd" or "postgres") as well as the status of the connection to the printed backend.

So instead of:

```
# curl -H "Authorization: Bearer $ACCESS_TOKEN" https://foobar.openchami.cluster/boot/v1/service/etcd
```

One now queries `/boot/v1/service/data`. Here is what a successful query looks like:

```
# curl -H "Authorization: Bearer $ACCESS_TOKEN" https://foobar.openchami.cluster/boot/v1/service/data
{"bss-storage-backend":{"name":"postgres","status":"connected"}}
```

In the logs (with debug enabled):

```
2024/08/05 17:04:06 [bss/pMoC8hss4a-000288] "GET http://foobar.openchami.cluster/boot/v1/service/data HTTP/1.1" from 172.16.0.253 - 200 65B in 886.28µs                                                           
2024/08/05 17:04:06 Test access to postgres using BootParamsGetAll() succeeded
2024/08/05 17:04:06 DEBUG: Boot parameters returned: [{[] [b4:2e:99:a6:06:47] [] nomodeset ro root=live:http://10.100.0.1:9000/boot-images/compute/slurm/rocky8.10-compute-slurm-base-latest ip=dhcp overlayroot=tmpfs overlayroot_cfgdisk=disabled apparmor=0 selinux=0 console=tty0 console=ttyS0,115200 ip6=off ds=nocloud-net;s=http://10.100.0.1:8000/cloud-init/compute/slurm/ http://10.100.0.1:9000/boot-images/efi-images/compute/slurm/vmlinuz-4.18.0-553.5.1.el8_10.x86_64 http://10.100.0.1:9000/boot-images/efi-images/compute/slurm/initramfs-4.18.0-553.5.1.el8_10.x86_64.img {map[] map[] {      }}}] 
```

And here is what an unsuccessful query looks like, e.g. if Postgres goes down:

```
# curl -H "Authorization: Bearer $ACCESS_TOKEN" https://foobar.openchami.cluster/boot/v1/service/data
{"bss-storage-backend":{"name":"postgres","status":"error"}}
```

In the log:

```
2024/08/05 17:04:59 [bss/pMoC8hss4a-000300] "GET http://foobar.openchami.cluster/boot/v1/service/data HTTP/1.1" from 172.16.0.253 - 500 61B in 1.443017ms                                                         
2024/08/05 17:04:59 Test access to postgres failed: BootParamsGetAll(): postgres.GetBootParamsAll: Unable to query database: dial tcp: lookup postgres on 127.0.0.11:53: no such host
```

This PR also adds back in the `/service/all` endpoint to get all statuses at once:

```
# curl -H "Authorization: Bearer $ACCESS_TOKEN" https://foobar.openchami.cluster/boot/v1/service/all | jq
{
  "bss-version": "1.31.1",
  "bss-status": "running",
  "bss-status-hsm": "connected",
  "bss-storage-backend": {
    "name": "postgres",
    "status": "connected"
  }
}
```