### PR TITLE
/endpoint-history: Support PostgreSQL

### DIFF
--- a/cmd/boot-script-service/boot_data.go
+++ b/cmd/boot-script-service/boot_data.go
@@ -800,11 +800,19 @@ func updateCloudInit(d *bssTypes.CloudInit, p bssTypes.CloudInit) bool {
 }
 
 func updateEndpointAccessed(name string, accessType bssTypes.EndpointType) {
-	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
-	key := fmt.Sprintf("%s/%s/%s", endpointAccessPfx, name, accessType)
-	if err := kvstore.Store(key, timestamp); err != nil {
-		log.Printf("Failed to store last access timestamp %s to key %s: %s",
-			timestamp, key, err)
+	if useSQL {
+		err := bssdb.LogEndpointAccess(name, accessType)
+		if err != nil {
+			log.Printf("Failed to store last access timestamp for endpoint=%q name=%q to postgres DB: %s",
+				accessType, name, err)
+		}
+	} else {
+		timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+		key := fmt.Sprintf("%s/%s/%s", endpointAccessPfx, name, accessType)
+		if err := kvstore.Store(key, timestamp); err != nil {
+			log.Printf("Failed to store last access timestamp %s to key %s: %s",
+				timestamp, key, err)
+		}
 	}
 }
 

--- a/cmd/boot-script-service/cloudInitAPI.go
+++ b/cmd/boot-script-service/cloudInitAPI.go
@@ -293,9 +293,17 @@ func endpointHistoryGetAPI(w http.ResponseWriter, r *http.Request) {
 		lastAccessTypeStruct = bssTypes.EndpointType(endpoint)
 	}
 
-	accesses, err := SearchEndpointAccessed(name, lastAccessTypeStruct)
+	var (
+		accesses []bssTypes.EndpointAccess
+		err      error
+	)
+	if useSQL {
+		accesses, err = bssdb.SearchEndpointAccesses(name, bssTypes.EndpointType(endpoint))
+	} else {
+		accesses, err = SearchEndpointAccessed(name, lastAccessTypeStruct)
+	}
 	if err != nil {
-		errMsg := fmt.Sprintf("Failed to search for name: %s, endpoint: %s", name, endpoint)
+		errMsg := fmt.Sprintf("Failed to search for name=%q, endpoint=%q: %v", name, endpoint, err)
 		base.SendProblemDetailsGeneric(w, http.StatusInternalServerError, errMsg)
 		log.Printf("BSS request failed: %s", errMsg)
 		return

--- a/cmd/boot-script-service/default_api.go
+++ b/cmd/boot-script-service/default_api.go
@@ -899,9 +899,7 @@ func BootscriptGet(w http.ResponseWriter, r *http.Request) {
 				log.Printf("BSS request succeeded for %s", descr)
 
 				// Record the fact this was asked for.
-				if !useSQL {
-					updateEndpointAccessed(comp.ID, bssTypes.EndpointTypeBootscript)
-				}
+				updateEndpointAccessed(comp.ID, bssTypes.EndpointTypeBootscript)
 			}
 		} else {
 			log.Printf("BSS request failed writing response for %s: %s", descr, err.Error())

--- a/go.mod
+++ b/go.mod
@@ -17,11 +17,13 @@ require (
 )
 
 require (
+	github.com/Cray-HPE/hms-xname v1.3.0
 	github.com/OpenCHAMI/jwtauth/v5 v5.0.0-20240321222802-e6cb468a2a18
 	github.com/OpenCHAMI/smd/v2 v2.12.15
 	github.com/go-chi/chi v1.5.1
 	github.com/go-chi/chi/v5 v5.0.11
 	github.com/golang-migrate/migrate/v4 v4.16.2
+	github.com/hashicorp/go-retryablehttp v0.7.4
 	github.com/lestrrat-go/jwx v1.2.28
 )
 
@@ -40,7 +42,6 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.4 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.7 // indirect
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/Cray-HPE/hms-s3 v1.9.2 h1:qZ/yTTr1+r1slDldOsqkcF736bnsiZ/002JVO7LGD/0
 github.com/Cray-HPE/hms-s3 v1.9.2/go.mod h1:p5pVsMDeOdXKssd9qyFtXo4ztrn2lhD04nrO8+NOi7g=
 github.com/Cray-HPE/hms-securestorage v1.13.0 h1:ut6z9TMtCzL902f9NPxcbtkkDuk9zbX6E30pP8j3k6Q=
 github.com/Cray-HPE/hms-securestorage v1.13.0/go.mod h1:P4CMKqQVlx/lv+AdyEjNQubZw2FKNyo/IAtFNgQ3VuI=
+github.com/Cray-HPE/hms-xname v1.3.0 h1:DQmetMniubqcaL6Cxarz9+7KFfWGSEizIhfPHIgC3Gw=
+github.com/Cray-HPE/hms-xname v1.3.0/go.mod h1:XKdjQSzoTps5KDOE8yWojBTAWASGaS6LfRrVDxwTQO8=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/OpenCHAMI/jwtauth/v5 v5.0.0-20240321222802-e6cb468a2a18 h1:oBPtXp9RVm9lk5zTmDLf+Vh21yDHpulBxUqGJQjwQCk=
 github.com/OpenCHAMI/jwtauth/v5 v5.0.0-20240321222802-e6cb468a2a18/go.mod h1:ggNHWgLfW/WRXcE8ZZC4S7UwHif16HVmyowOCWdNSN8=

--- a/internal/postgres/bootparams.go
+++ b/internal/postgres/bootparams.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Triad National Security, LLC. All rights reserved.
+// Copyright © 2024 Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
@@ -22,12 +22,7 @@ import (
 	"github.com/OpenCHAMI/bss/pkg/bssTypes"
 	"github.com/docker/distribution/uuid"
 	"github.com/jmoiron/sqlx"
-	"github.com/jmoiron/sqlx/reflectx"
 	_ "github.com/lib/pq"
-)
-
-const (
-	xNameRegex = `^x([0-9]{1,4})c([0-7])(s([0-9]{1,4}))?b([0])(n([0-9]{1,4}))?$`
 )
 
 type Node struct {
@@ -67,71 +62,6 @@ type BootDataDatabase struct {
 type bgbc struct {
 	Bg BootGroup
 	Bc BootConfig
-}
-
-// makeKey creates a key from a key and subkey.  If key is not empty, it will
-// be prepended with a '/' if it does not already start with one.  If subkey is
-// not empty, it will be appended with a '/' if it does not already end with
-// one.  The two will be concatenated with no '/' between them.
-func makeKey(key, subkey string) string {
-	ret := key
-	if key != "" && key[0] != '/' {
-		ret = "/" + key
-	}
-	if subkey != "" {
-		if subkey[0] != '/' {
-			ret += "/"
-		}
-		ret += subkey
-	}
-	return ret
-}
-
-// tagToColName extracts the field name from the JSON struct tag. Replace - with
-// _.
-// E.g: From `json:"params,omitempty"` comes `params`.
-func tagToColName(tag string) string {
-	re := regexp.MustCompile(`json:"([a-z0-9-]+)(?:,[a-z0-9-]+)*"`)
-	colName := re.FindString(tag)
-	return strings.Replace(colName, "-", "_", -1)
-}
-
-// fieldNameToColName converts the struct field name (in Pascal case) into
-// the format for the database column (in snake case).
-func fieldNameToColName(fieldName string) string {
-	firstCap := regexp.MustCompile(`(.)([A-Z][a-z]+)`)
-	allCaps := regexp.MustCompile(`([a-z0-9])([A-Z])`)
-	colName := firstCap.ReplaceAllString(fieldName, `${1}_${2}`)
-	colName = allCaps.ReplaceAllString(colName, `${1}_${2}`)
-	return strings.ToLower(colName)
-}
-
-// Connect opens a new connections to a Postgres database and ensures it is reachable.
-// If not, an error is thrown.
-func Connect(host string, port uint, dbName, user, password string, ssl bool, extraDbOpts string) (BootDataDatabase, error) {
-	var (
-		sslmode string
-		bddb    BootDataDatabase
-	)
-	if ssl {
-		sslmode = "verify-full"
-	} else {
-		sslmode = "disable"
-	}
-	connStr := fmt.Sprintf("user=%s password=%s host=%s port=%d dbname=%s sslmode=%s", user, password, host, port, dbName, sslmode)
-	if extraDbOpts != "" {
-		connStr += " " + extraDbOpts
-	}
-	db, err := sqlx.Connect("postgres", connStr)
-	if err != nil {
-		return bddb, err
-	}
-	// Create a new mapper which will use the struct field tag "json" instead of "db",
-	// and ignore extra JSON config values, e.g. "omitempty".
-	db.Mapper = reflectx.NewMapperTagFunc("json", fieldNameToColName, tagToColName)
-	bddb.DB = db
-
-	return bddb, err
 }
 
 // NewNode creates a new Node and populates it with the boot MAC address (converts to lower case),
@@ -714,63 +644,6 @@ func (bddb BootDataDatabase) getConfigsWithNodes(nodeIds []string) (map[bgbc][]N
 	}
 
 	return bgbcToN, err
-}
-
-func stringSliceToSql(ss []string) string {
-	if len(ss) == 0 {
-		return "('')"
-	}
-	sep := ""
-	s := "("
-	for i, st := range ss {
-		s += sep + fmt.Sprintf("'%s'", st)
-		if i == len(ss)-1 {
-			sep = ""
-		} else {
-			sep = ", "
-		}
-	}
-	s += ")"
-	return s
-}
-
-func int32SliceToSql(is []int32) string {
-	sep := ""
-	s := "("
-	for i, in := range is {
-		s += sep + fmt.Sprintf("%d", in)
-		if i == len(is)-1 {
-			sep = ""
-		} else {
-			sep = ", "
-		}
-	}
-	s += ")"
-	return s
-}
-
-// Return the intersection of a and b (matches) and those elements in b but not in a (exclusions).
-func getMatches(a, b []string) (matches, exclusions []string) {
-	for _, aVal := range a {
-		aInB := false
-		for _, bVal := range b {
-			if aVal == bVal {
-				matches = append(matches, aVal)
-				aInB = true
-				break
-			}
-		}
-		if !aInB {
-			exclusions = append(exclusions, aVal)
-		}
-	}
-	return matches, exclusions
-}
-
-// Close calls the Close() method on the database object within the BootDataDatabase. If it errs, an
-// error is returned.
-func (bddb BootDataDatabase) Close() error {
-	return bddb.DB.Close()
 }
 
 // addBootConfigByGroup adds one or more BootConfig/BootGroup to the boot data database, assuming

--- a/internal/postgres/common.go
+++ b/internal/postgres/common.go
@@ -1,0 +1,149 @@
+// Copyright © 2024 Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001
+// for Los Alamos National Laboratory (LANL), which is operated by Triad
+// National Security, LLC for the U.S. Department of Energy/National Nuclear
+// Security Administration. All rights in the program are reserved by Triad
+// National Security, LLC, and the U.S. Department of Energy/National Nuclear
+// Security Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide license
+// in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do
+// so.
+
+package postgres
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/jmoiron/sqlx/reflectx"
+)
+
+const (
+	xNameRegex = `^x([0-9]{1,4})c([0-7])(s([0-9]{1,4}))?b([0])(n([0-9]{1,4}))?$`
+)
+
+// makeKey creates a key from a key and subkey.  If key is not empty, it will
+// be prepended with a '/' if it does not already start with one.  If subkey is
+// not empty, it will be appended with a '/' if it does not already end with
+// one.  The two will be concatenated with no '/' between them.
+func makeKey(key, subkey string) string {
+	ret := key
+	if key != "" && key[0] != '/' {
+		ret = "/" + key
+	}
+	if subkey != "" {
+		if subkey[0] != '/' {
+			ret += "/"
+		}
+		ret += subkey
+	}
+	return ret
+}
+
+// tagToColName extracts the field name from the JSON struct tag. Replace - with
+// _.
+// E.g: From `json:"params,omitempty"` comes `params`.
+func tagToColName(tag string) string {
+	re := regexp.MustCompile(`json:"([a-z0-9-]+)(?:,[a-z0-9-]+)*"`)
+	colName := re.FindString(tag)
+	return strings.Replace(colName, "-", "_", -1)
+}
+
+// fieldNameToColName converts the struct field name (in Pascal case) into
+// the format for the database column (in snake case).
+func fieldNameToColName(fieldName string) string {
+	firstCap := regexp.MustCompile(`(.)([A-Z][a-z]+)`)
+	allCaps := regexp.MustCompile(`([a-z0-9])([A-Z])`)
+	colName := firstCap.ReplaceAllString(fieldName, `${1}_${2}`)
+	colName = allCaps.ReplaceAllString(colName, `${1}_${2}`)
+	return strings.ToLower(colName)
+}
+
+func stringSliceToSql(ss []string) string {
+	if len(ss) == 0 {
+		return "('')"
+	}
+	sep := ""
+	s := "("
+	for i, st := range ss {
+		s += sep + fmt.Sprintf("'%s'", st)
+		if i == len(ss)-1 {
+			sep = ""
+		} else {
+			sep = ", "
+		}
+	}
+	s += ")"
+	return s
+}
+
+func int32SliceToSql(is []int32) string {
+	sep := ""
+	s := "("
+	for i, in := range is {
+		s += sep + fmt.Sprintf("%d", in)
+		if i == len(is)-1 {
+			sep = ""
+		} else {
+			sep = ", "
+		}
+	}
+	s += ")"
+	return s
+}
+
+// Return the intersection of a and b (matches) and those elements in b but not in a (exclusions).
+func getMatches(a, b []string) (matches, exclusions []string) {
+	for _, aVal := range a {
+		aInB := false
+		for _, bVal := range b {
+			if aVal == bVal {
+				matches = append(matches, aVal)
+				aInB = true
+				break
+			}
+		}
+		if !aInB {
+			exclusions = append(exclusions, aVal)
+		}
+	}
+	return matches, exclusions
+}
+
+// Connect opens a new connections to a Postgres database and ensures it is reachable.
+// If not, an error is thrown.
+func Connect(host string, port uint, dbName, user, password string, ssl bool, extraDbOpts string) (BootDataDatabase, error) {
+	var (
+		sslmode string
+		bddb    BootDataDatabase
+	)
+	if ssl {
+		sslmode = "verify-full"
+	} else {
+		sslmode = "disable"
+	}
+	connStr := fmt.Sprintf("user=%s password=%s host=%s port=%d dbname=%s sslmode=%s", user, password, host, port, dbName, sslmode)
+	if extraDbOpts != "" {
+		connStr += " " + extraDbOpts
+	}
+	db, err := sqlx.Connect("postgres", connStr)
+	if err != nil {
+		return bddb, err
+	}
+	// Create a new mapper which will use the struct field tag "json" instead of "db",
+	// and ignore extra JSON config values, e.g. "omitempty".
+	db.Mapper = reflectx.NewMapperTagFunc("json", fieldNameToColName, tagToColName)
+	bddb.DB = db
+
+	return bddb, err
+}
+
+// Close calls the Close() method on the database object within the BootDataDatabase. If it errs, an
+// error is returned.
+func (bddb BootDataDatabase) Close() error {
+	return bddb.DB.Close()
+}

--- a/internal/postgres/common.go
+++ b/internal/postgres/common.go
@@ -22,10 +22,6 @@ import (
 	"github.com/jmoiron/sqlx/reflectx"
 )
 
-const (
-	xNameRegex = `^x([0-9]{1,4})c([0-7])(s([0-9]{1,4}))?b([0])(n([0-9]{1,4}))?$`
-)
-
 // makeKey creates a key from a key and subkey.  If key is not empty, it will
 // be prepended with a '/' if it does not already start with one.  If subkey is
 // not empty, it will be appended with a '/' if it does not already end with

--- a/internal/postgres/endpoints.go
+++ b/internal/postgres/endpoints.go
@@ -13,8 +13,53 @@
 
 package postgres
 
+import (
+	"fmt"
+	"time"
+
+	"github.com/OpenCHAMI/bss/pkg/bssTypes"
+)
+
 type EndpointAccess struct {
 	Name      string `json:"name"`
 	Endpoint  string `json:"endpoint"`
 	LastEpoch int64  `json:"last_epoch"`
+}
+
+// LogEndpointAccess takes a name and an endpoint type and adds a table entry to
+// the endpoint_accesses table with the current timestamp.
+func (bddb BootDataDatabase) LogEndpointAccess(name string, endpointType bssTypes.EndpointType) (err error) {
+	if name == "" {
+		err = fmt.Errorf("postgres.LogEndpointAccess: Argument 'name' cannot be empty")
+		return
+	}
+	if endpointType == "" {
+		err = fmt.Errorf("postgres.LogEndpointAccess: Argument 'endpointType' cannot be empty")
+		return
+	}
+
+	ts := time.Now()
+	ea := EndpointAccess{
+		Name: name,
+		Endpoint: string(endpointType),
+		LastEpoch: ts.Unix(),
+	}
+
+	err = bddb.addEndpointAccess(ea)
+	if err != nil {
+		err = fmt.Errorf("postgres.LogEndpointAccess: %v", err)
+	}
+
+	return
+}
+
+func (bddb BootDataDatabase) addEndpointAccess(ea EndpointAccess) (err error) {
+	execStr := `INSERT INTO endpoint_access (name, endpoint, last_epoch) VALUES ($1, $2, $3);`
+	_, err = bddb.DB.Exec(execStr, ea.Name, ea.Endpoint, ea.LastEpoch)
+	if err != nil {
+		err = fmt.Errorf("Error executing query to add endpoint access %v: %v", ea, err)
+		return
+	}
+
+	return
 }

--- a/internal/postgres/endpoints.go
+++ b/internal/postgres/endpoints.go
@@ -14,6 +14,7 @@
 package postgres
 
 import (
+	"database/sql"
 	"fmt"
 	"time"
 
@@ -24,6 +25,65 @@ type EndpointAccess struct {
 	Name      string `json:"name"`
 	Endpoint  string `json:"endpoint"`
 	LastEpoch int64  `json:"last_epoch"`
+}
+
+// SearchEndpointAccesses takes the name of a node (xname) and a BSS endpoint as
+// arguments and returns a slice of EndpointAccess structs representing
+// timestamps of when the passed endpoint was accessed for the passed name. If
+// endpointType is empty, then all endpoint accesses for the given name are
+// returned. If name is empty, then all accesses for the given endpoint are
+// returned. If both arguments are empty, then all endpoint accesses for all
+// names are returned.
+func (bddb BootDataDatabase) SearchEndpointAccesses(name string, endpointType bssTypes.EndpointType) (accesses []bssTypes.EndpointAccess, err error) {
+	qstr := `SELECT * FROM endpoint_access`
+
+	// Only construct query with WHERE clause if both arguments are NOT
+	// empty.
+	if name != "" || endpointType != "" {
+		qstr += ` WHERE`
+		strs := []string{name, string(endpointType)}
+		for first, i := true, 0; i < len(strs); i++ {
+			if strs[i] != "" {
+				if !first {
+					qstr += ` AND`
+				}
+				switch i {
+				case 0:
+					qstr += fmt.Sprintf(` name = '%s'`, strs[0])
+				case 1:
+					qstr += fmt.Sprintf(` endpoint = '%s'`, strs[1])
+				}
+				first = false
+			}
+		}
+	}
+	qstr += `;`
+	var rows *sql.Rows
+	rows, err = bddb.DB.Query(qstr)
+	if err != nil {
+		err = fmt.Errorf("postgres.SearchEndpointAccesses: Could not query endpoint access table in boot database: %v", err)
+		return
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			ea bssTypes.EndpointAccess
+		)
+		err = rows.Scan(&ea.Name, &ea.Endpoint, &ea.LastEpoch)
+		if err != nil {
+			err = fmt.Errorf("postgres.SearchEndpointAccesses: Could not scan results into EndpointAccess: %v", err)
+			return
+		}
+		accesses = append(accesses, ea)
+	}
+	// Did a rows.Next() return an error?
+	if err = rows.Err(); err != nil {
+		err = fmt.Errorf("postgres.SearchEndpointAccesses: Could not parse query results: %v", err)
+		return
+	}
+
+	return
 }
 
 // LogEndpointAccess takes a name and an endpoint type and adds a table entry to

--- a/internal/postgres/endpoints.go
+++ b/internal/postgres/endpoints.go
@@ -1,0 +1,14 @@
+// Copyright © 2024 Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001
+// for Los Alamos National Laboratory (LANL), which is operated by Triad
+// National Security, LLC for the U.S. Department of Energy/National Nuclear
+// Security Administration. All rights in the program are reserved by Triad
+// National Security, LLC, and the U.S. Department of Energy/National Nuclear
+// Security Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide license
+// in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do
+// so.
+
+package postgres

--- a/internal/postgres/endpoints.go
+++ b/internal/postgres/endpoints.go
@@ -12,3 +12,9 @@
 // so.
 
 package postgres
+
+type EndpointAccess struct {
+	Name      string `json:"name"`
+	Endpoint  string `json:"endpoint"`
+	LastEpoch int64  `json:"last_epoch"`
+}

--- a/migrations/postgres/3_create_version2.down.sql
+++ b/migrations/postgres/3_create_version2.down.sql
@@ -1,0 +1,17 @@
+-- Copyright © 2024 Triad National Security, LLC. All rights reserved.
+--
+-- This program was produced under U.S. Government contract 89233218CNA000001 for
+-- Los Alamos National Laboratory (LANL), which is operated by Triad National
+-- Security, LLC for the U.S. Department of Energy/National Nuclear Security
+-- Administration. All rights in the program are reserved by Triad National
+-- Security, LLC, and the U.S. Department of Energy/National Nuclear Security
+-- Administration. The Government is granted for itself and others acting on its
+-- behalf a nonexclusive, paid-up, irrevocable worldwide license in this material
+-- to reproduce, prepare derivative works, distribute copies to the public,
+-- perform publicly and display publicly, and to permit others to do so.
+
+BEGIN;
+
+DROP TABLE IF EXISTS endpoint_access;
+
+COMMIT;

--- a/migrations/postgres/3_create_version2.up.sql
+++ b/migrations/postgres/3_create_version2.up.sql
@@ -1,0 +1,24 @@
+-- Copyright © 2024 Triad National Security, LLC. All rights reserved.
+--
+-- This program was produced under U.S. Government contract 89233218CNA000001 for
+-- Los Alamos National Laboratory (LANL), which is operated by Triad National
+-- Security, LLC for the U.S. Department of Energy/National Nuclear Security
+-- Administration. All rights in the program are reserved by Triad National
+-- Security, LLC, and the U.S. Department of Energy/National Nuclear Security
+-- Administration. The Government is granted for itself and others acting on its
+-- behalf a nonexclusive, paid-up, irrevocable worldwide license in this material
+-- to reproduce, prepare derivative works, distribute copies to the public,
+-- perform publicly and display publicly, and to permit others to do so.
+
+BEGIN;
+
+--
+-- endpoint_access - Endpoint access history
+--
+CREATE TABLE IF NOT EXISTS endpoint_access (
+	name varchar,
+	endpoint varchar,
+	last_epoch int
+);
+
+COMMIT;


### PR DESCRIPTION
Introduces one of multiple fixes for #20.

Modify the `/endpoint-history` endpoint to support PostgreSQL, not just EtcD.