### PR TITLE
Change copyrights to the OpenCHAMI MIT copyright

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ kubernetes/.packaged/
 *.pem
 dist/
 
+# files built by make binaries
+/.version
+/boot-script-service
+/bss-init

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ version:
 
 .PHONY: clean
 clean:
-	rm -f $(BINARIES)
+	rm -f $(BINARIES) .version
 
 .PHONY: snyk
 snyk:

--- a/cmd/boot-script-service/oauth.go
+++ b/cmd/boot-script-service/oauth.go
@@ -1,15 +1,24 @@
-// Copyright © 2024 Triad National Security, LLC. All rights reserved.
+// MIT License
 //
-// This program was produced under U.S. Government contract 89233218CNA000001
-// for Los Alamos National Laboratory (LANL), which is operated by Triad
-// National Security, LLC for the U.S. Department of Energy/National Nuclear
-// Security Administration. All rights in the program are reserved by Triad
-// National Security, LLC, and the U.S. Department of Energy/National Nuclear
-// Security Administration. The Government is granted for itself and others
-// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide license
-// in this material to reproduce, prepare derivative works, distribute copies to
-// the public, perform publicly and display publicly, and to permit others to do
-// so.
+// Copyright © 2024 Contributors to the OpenCHAMI Project
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 package main
 

--- a/cmd/bss-init/main.go
+++ b/cmd/bss-init/main.go
@@ -1,14 +1,24 @@
-// Copyright © 2023 Triad National Security, LLC. All rights reserved.
+// MIT License
 //
-// This program was produced under U.S. Government contract 89233218CNA000001 for
-// Los Alamos National Laboratory (LANL), which is operated by Triad National
-// Security, LLC for the U.S. Department of Energy/National Nuclear Security
-// Administration. All rights in the program are reserved by Triad National
-// Security, LLC, and the U.S. Department of Energy/National Nuclear Security
-// Administration. The Government is granted for itself and others acting on its
-// behalf a nonexclusive, paid-up, irrevocable worldwide license in this material
-// to reproduce, prepare derivative works, distribute copies to the public,
-// perform publicly and display publicly, and to permit others to do so.
+// Copyright © 2023 Contributors to the OpenCHAMI Project
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 /*
  * Boot Script Server Initializer
@@ -30,7 +40,6 @@ import (
 	"strings"
 	"time"
 
-	_ "github.com/lib/pq"
 	"github.com/golang-migrate/migrate/v4"
 	db "github.com/golang-migrate/migrate/v4/database"
 	pg "github.com/golang-migrate/migrate/v4/database/postgres"

--- a/internal/postgres/bootparams.go
+++ b/internal/postgres/bootparams.go
@@ -1,15 +1,24 @@
-// Copyright © 2024 Triad National Security, LLC. All rights reserved.
+// MIT License
 //
-// This program was produced under U.S. Government contract 89233218CNA000001
-// for Los Alamos National Laboratory (LANL), which is operated by Triad
-// National Security, LLC for the U.S. Department of Energy/National Nuclear
-// Security Administration. All rights in the program are reserved by Triad
-// National Security, LLC, and the U.S. Department of Energy/National Nuclear
-// Security Administration. The Government is granted for itself and others
-// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide license
-// in this material to reproduce, prepare derivative works, distribute copies to
-// the public, perform publicly and display publicly, and to permit others to do
-// so.
+// Copyright © 2024 Contributors to the OpenCHAMI Project
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 package postgres
 
@@ -18,10 +27,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Cray-HPE/hms-xname/xnames"
 	"github.com/OpenCHAMI/bss/pkg/bssTypes"
 	"github.com/docker/distribution/uuid"
 	"github.com/jmoiron/sqlx"
-	"github.com/Cray-HPE/hms-xname/xnames"
 	_ "github.com/lib/pq"
 )
 

--- a/internal/postgres/common.go
+++ b/internal/postgres/common.go
@@ -1,15 +1,24 @@
-// Copyright © 2024 Triad National Security, LLC. All rights reserved.
+// MIT License
 //
-// This program was produced under U.S. Government contract 89233218CNA000001
-// for Los Alamos National Laboratory (LANL), which is operated by Triad
-// National Security, LLC for the U.S. Department of Energy/National Nuclear
-// Security Administration. All rights in the program are reserved by Triad
-// National Security, LLC, and the U.S. Department of Energy/National Nuclear
-// Security Administration. The Government is granted for itself and others
-// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide license
-// in this material to reproduce, prepare derivative works, distribute copies to
-// the public, perform publicly and display publicly, and to permit others to do
-// so.
+// Copyright © 2024 Contributors to the OpenCHAMI Project
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 package postgres
 

--- a/internal/postgres/endpoints.go
+++ b/internal/postgres/endpoints.go
@@ -1,15 +1,24 @@
-// Copyright © 2024 Triad National Security, LLC. All rights reserved.
+// MIT License
 //
-// This program was produced under U.S. Government contract 89233218CNA000001
-// for Los Alamos National Laboratory (LANL), which is operated by Triad
-// National Security, LLC for the U.S. Department of Energy/National Nuclear
-// Security Administration. All rights in the program are reserved by Triad
-// National Security, LLC, and the U.S. Department of Energy/National Nuclear
-// Security Administration. The Government is granted for itself and others
-// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide license
-// in this material to reproduce, prepare derivative works, distribute copies to
-// the public, perform publicly and display publicly, and to permit others to do
-// so.
+// Copyright © 2024 Contributors to the OpenCHAMI Project
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 package postgres
 
@@ -100,8 +109,8 @@ func (bddb BootDataDatabase) LogEndpointAccess(name string, endpointType bssType
 
 	ts := time.Now()
 	ea := EndpointAccess{
-		Name: name,
-		Endpoint: string(endpointType),
+		Name:      name,
+		Endpoint:  string(endpointType),
 		LastEpoch: ts.Unix(),
 	}
 

--- a/internal/postgres/errors.go
+++ b/internal/postgres/errors.go
@@ -1,15 +1,24 @@
-// Copyright © 2024 Triad National Security, LLC. All rights reserved.
+// MIT License
 //
-// This program was produced under U.S. Government contract 89233218CNA000001
-// for Los Alamos National Laboratory (LANL), which is operated by Triad
-// National Security, LLC for the U.S. Department of Energy/National Nuclear
-// Security Administration. All rights in the program are reserved by Triad
-// National Security, LLC, and the U.S. Department of Energy/National Nuclear
-// Security Administration. The Government is granted for itself and others
-// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide license
-// in this material to reproduce, prepare derivative works, distribute copies to
-// the public, perform publicly and display publicly, and to permit others to do
-// so.
+// Copyright © 2024 Contributors to the OpenCHAMI Project
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 package postgres
 

--- a/migrations/postgres/1_create_db_init.down.sql
+++ b/migrations/postgres/1_create_db_init.down.sql
@@ -1,13 +1,23 @@
--- Copyright © 2023 Triad National Security, LLC. All rights reserved.
+-- MIT License
 --
--- This program was produced under U.S. Government contract 89233218CNA000001 for
--- Los Alamos National Laboratory (LANL), which is operated by Triad National
--- Security, LLC for the U.S. Department of Energy/National Nuclear Security
--- Administration. All rights in the program are reserved by Triad National
--- Security, LLC, and the U.S. Department of Energy/National Nuclear Security
--- Administration. The Government is granted for itself and others acting on its
--- behalf a nonexclusive, paid-up, irrevocable worldwide license in this material
--- to reproduce, prepare derivative works, distribute copies to the public,
--- perform publicly and display publicly, and to permit others to do so.
+-- Copyright © 2023 Contributors to the OpenCHAMI Project
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in all
+-- copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
 
 -- DROP SCHEMA IF EXISTS bssdb;

--- a/migrations/postgres/1_create_db_init.up.sql
+++ b/migrations/postgres/1_create_db_init.up.sql
@@ -1,13 +1,23 @@
--- Copyright © 2023 Triad National Security, LLC. All rights reserved.
+-- MIT License
 --
--- This program was produced under U.S. Government contract 89233218CNA000001 for
--- Los Alamos National Laboratory (LANL), which is operated by Triad National
--- Security, LLC for the U.S. Department of Energy/National Nuclear Security
--- Administration. All rights in the program are reserved by Triad National
--- Security, LLC, and the U.S. Department of Energy/National Nuclear Security
--- Administration. The Government is granted for itself and others acting on its
--- behalf a nonexclusive, paid-up, irrevocable worldwide license in this material
--- to reproduce, prepare derivative works, distribute copies to the public,
--- perform publicly and display publicly, and to permit others to do so.
+-- Copyright © 2023 Contributors to the OpenCHAMI Project
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in all
+-- copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
 
 -- CREATE SCHEMA IF NOT EXISTS bssdb;

--- a/migrations/postgres/2_create_version1.down.sql
+++ b/migrations/postgres/2_create_version1.down.sql
@@ -1,14 +1,24 @@
--- Copyright © 2023 Triad National Security, LLC. All rights reserved.
+-- MIT License
 --
--- This program was produced under U.S. Government contract 89233218CNA000001 for
--- Los Alamos National Laboratory (LANL), which is operated by Triad National
--- Security, LLC for the U.S. Department of Energy/National Nuclear Security
--- Administration. All rights in the program are reserved by Triad National
--- Security, LLC, and the U.S. Department of Energy/National Nuclear Security
--- Administration. The Government is granted for itself and others acting on its
--- behalf a nonexclusive, paid-up, irrevocable worldwide license in this material
--- to reproduce, prepare derivative works, distribute copies to the public,
--- perform publicly and display publicly, and to permit others to do so.
+-- Copyright © 2023 Contributors to the OpenCHAMI Project
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in all
+-- copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
 
 BEGIN;
 

--- a/migrations/postgres/2_create_version1.up.sql
+++ b/migrations/postgres/2_create_version1.up.sql
@@ -1,14 +1,24 @@
--- Copyright © 2023 Triad National Security, LLC. All rights reserved.
+-- MIT License
 --
--- This program was produced under U.S. Government contract 89233218CNA000001 for
--- Los Alamos National Laboratory (LANL), which is operated by Triad National
--- Security, LLC for the U.S. Department of Energy/National Nuclear Security
--- Administration. All rights in the program are reserved by Triad National
--- Security, LLC, and the U.S. Department of Energy/National Nuclear Security
--- Administration. The Government is granted for itself and others acting on its
--- behalf a nonexclusive, paid-up, irrevocable worldwide license in this material
--- to reproduce, prepare derivative works, distribute copies to the public,
--- perform publicly and display publicly, and to permit others to do so.
+-- Copyright © 2023 Contributors to the OpenCHAMI Project
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in all
+-- copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
 
 BEGIN;
 

--- a/migrations/postgres/3_create_version2.down.sql
+++ b/migrations/postgres/3_create_version2.down.sql
@@ -1,14 +1,24 @@
--- Copyright © 2024 Triad National Security, LLC. All rights reserved.
+-- MIT License
 --
--- This program was produced under U.S. Government contract 89233218CNA000001 for
--- Los Alamos National Laboratory (LANL), which is operated by Triad National
--- Security, LLC for the U.S. Department of Energy/National Nuclear Security
--- Administration. All rights in the program are reserved by Triad National
--- Security, LLC, and the U.S. Department of Energy/National Nuclear Security
--- Administration. The Government is granted for itself and others acting on its
--- behalf a nonexclusive, paid-up, irrevocable worldwide license in this material
--- to reproduce, prepare derivative works, distribute copies to the public,
--- perform publicly and display publicly, and to permit others to do so.
+-- Copyright © 2024 Contributors to the OpenCHAMI Project
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in all
+-- copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
 
 BEGIN;
 

--- a/migrations/postgres/3_create_version2.up.sql
+++ b/migrations/postgres/3_create_version2.up.sql
@@ -1,14 +1,24 @@
--- Copyright © 2024 Triad National Security, LLC. All rights reserved.
+-- MIT License
 --
--- This program was produced under U.S. Government contract 89233218CNA000001 for
--- Los Alamos National Laboratory (LANL), which is operated by Triad National
--- Security, LLC for the U.S. Department of Energy/National Nuclear Security
--- Administration. All rights in the program are reserved by Triad National
--- Security, LLC, and the U.S. Department of Energy/National Nuclear Security
--- Administration. The Government is granted for itself and others acting on its
--- behalf a nonexclusive, paid-up, irrevocable worldwide license in this material
--- to reproduce, prepare derivative works, distribute copies to the public,
--- perform publicly and display publicly, and to permit others to do so.
+-- Copyright © 2024 Contributors to the OpenCHAMI Project
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in all
+-- copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
 
 BEGIN;
 


### PR DESCRIPTION
Changed the copyright on a few files to the OpenCHAMI MIT License: https://github.com/OpenCHAMI/.github/blob/main/LICENSE

I'm suggesting this change so that these files can be brought back into CSM.

The following changes were also made:
1. Added the header "MIT License" to the copyrights. This a convenience for someone trying to figure out what type of copyright this is.
2. Added files generated by the Makefile to .gitignore
3. Added .version to files removed by `make clean`
4. Ran go fmt on a few files (this was automatically done by my editor)