### PR TITLE
chore: add buildBootScript test

### DIFF
--- a/cmd/boot-script-service/testdata/TestBuildBootScript/ds_override.txt
+++ b/cmd/boot-script-service/testdata/TestBuildBootScript/ds_override.txt
@@ -1,0 +1,7 @@
+#!ipxe
+kernel --name kernel kernel_path initrd=initrd ds=override-example;subparam=foo kernel_params  xname=sp_xname nid=sp_nid bss_referral_token=sp_rt || goto boot_retry
+initrd --name initrd initrd_path || goto boot_retry
+boot || goto boot_retry
+:boot_retry
+sleep 30
+chain_val

--- a/cmd/boot-script-service/testdata/TestBuildBootScript/garbage_val.txt
+++ b/cmd/boot-script-service/testdata/TestBuildBootScript/garbage_val.txt
@@ -1,0 +1,7 @@
+#!ipxe
+kernel --name kernel kernel_path initrd=initrd bd_params kernel_params  xname=sp_xname nid=sp_nid bss_referral_token=sp_rt ds=nocloud-net;s=/ || goto boot_retry
+initrd --name initrd initrd_path || goto boot_retry
+boot || goto boot_retry
+:boot_retry
+sleep 30
+chain_val

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/OpenCHAMI/bss
 
-go 1.23
-toolchain go1.24.1
+go 1.23.0
 
+toolchain go1.24.2
 
 require (
 	github.com/Cray-HPE/hms-base v1.15.1
@@ -28,6 +28,7 @@ require (
 	github.com/openchami/chi-middleware/auth v0.0.0-20240812224658-b16b83c70700
 	github.com/openchami/chi-middleware/log v0.0.0-20240812224658-b16b83c70700
 	github.com/rs/zerolog v1.33.0
+	github.com/stretchr/testify v1.10.0
 )
 
 require (
@@ -37,6 +38,7 @@ require (
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
@@ -65,6 +67,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
@@ -83,4 +86,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241104194629-dd2ea8efbc28 // indirect
 	google.golang.org/grpc v1.68.0 // indirect
 	google.golang.org/protobuf v1.35.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
Draft: this functions, but I intend to add more cases and continue work on #67 further up the chain

Add a basic unit test for buildBootScript, testing one successful case with unremarkable inputs, one failure case for missing kernel path, and one successful case overriding a generated param.