### PR TITLE
Added JSON parameter to /bootscript

### DIFF
--- a/cmd/boot-script-service/boot_data.go
+++ b/cmd/boot-script-service/boot_data.go
@@ -71,11 +71,11 @@ type ImageData struct {
 }
 
 type BootData struct {
-	Params        string
-	Kernel        ImageData
-	Initrd        ImageData
-	CloudInit     bssTypes.CloudInit
-	ReferralToken string
+	Params        string             `json:"params,omitempty"`
+	Kernel        ImageData          `json:"kernel,omitempty"`
+	Initrd        ImageData          `json:"initrd,omitempty"`
+	CloudInit     bssTypes.CloudInit `json:"-"`
+	ReferralToken string             `json:"-"`
 }
 
 const DefaultTag = "Default"

--- a/cmd/boot-script-service/default_api.go
+++ b/cmd/boot-script-service/default_api.go
@@ -829,6 +829,21 @@ func BootscriptGet(w http.ResponseWriter, r *http.Request) {
 	debugf("bd: %v\n", bd)
 	debugf("comp: %v\n", comp)
 
+	is_json, _ := getIntParam(r, "json", 0)
+	if is_json != 0 {
+		b, err := json.Marshal(bd)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, "Failed to marshal JSON response: %v", err)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		w.WriteHeader(http.StatusOK)
+		w.Write(b)
+		return
+	}
+
 	var script string
 	var err error
 


### PR DESCRIPTION
Allows the boot script endpoint to output JSON instead of an iPXE script if the "json" query parameter has a non-zero value.