### PR TITLE
fix: inject BOOTIF kernel param from requesting MAC at bootscript serve time

### DIFF
--- a/cmd/boot-script-service/default_api.go
+++ b/cmd/boot-script-service/default_api.go
@@ -89,6 +89,7 @@ type scriptParams struct {
 	xname         string
 	nid           string
 	referralToken string
+	mac           string
 }
 
 // Note that we allow an empty string if the env variable is defined as such.
@@ -689,6 +690,11 @@ func buildParams(bd BootData, sp scriptParams, role, subRole string) (string, er
 	if sp.referralToken != "" {
 		params = checkParam(params, "bss_referral_token=", sp.referralToken)
 	}
+	// Add BOOTIF to params to force 1st mac
+	if sp.mac != "" {
+		bootif := "01-" + strings.ReplaceAll(sp.mac, ":", "-")
+		params = checkParam(params, "BOOTIF=", bootif)
+	}
 
 	// Inject the cloud init address info into the kernel params. If the target
 	// image does not have cloud-init enabled this wont hurt anything.
@@ -841,7 +847,7 @@ func BootscriptGet(w http.ResponseWriter, r *http.Request) {
 		log.Printf("BSS request failed: bootscript request without mac=, name=, or nid= parameter")
 		return
 	}
-	sp := scriptParams{comp.ID, comp.NID.String(), bd.ReferralToken}
+	sp := scriptParams{comp.ID, comp.NID.String(), bd.ReferralToken, mac}
 
 	debugf("bd: %v\n", bd)
 	debugf("comp: %v\n", comp)

--- a/cmd/boot-script-service/default_api_test.go
+++ b/cmd/boot-script-service/default_api_test.go
@@ -311,6 +311,113 @@ func TestBuildParams_Success(t *testing.T) {
 				"nid=0",
 				fmt.Sprintf("ds=nocloud-net;s=%s/", advertiseAddress),
 			}},
+		{
+			// BOOTIF injection with MAC address
+			BootData{
+				Params: "root=nfs:example/path/to/rootfs:ro",
+				Kernel: ImageData{Path: "http://example/path/to/vmlinuz"},
+				Initrd: ImageData{Path: "http://example/path/to/initramfs.img"},
+			},
+			scriptParams{
+				xname: "x0000c0s0b0n0",
+				nid:   "0",
+				mac:   "aa:bb:cc:dd:ee:ff",
+			},
+			[]string{
+				"initrd=initrd",
+				"root=nfs:example/path/to/rootfs:ro",
+				"xname=x0000c0s0b0n0",
+				"nid=0",
+				"BOOTIF=01-aa-bb-cc-dd-ee-ff",
+				fmt.Sprintf("ds=nocloud-net;s=%s/", advertiseAddress),
+			},
+		},
+		{
+			// No BOOTIF injection when mac is empty
+			BootData{
+				Params: "root=nfs:example/path/to/rootfs:ro",
+				Kernel: ImageData{Path: "http://example/path/to/vmlinuz"},
+				Initrd: ImageData{Path: "http://example/path/to/initramfs.img"},
+			},
+			scriptParams{
+				xname: "x0000c0s0b0n0",
+				nid:   "0",
+				mac:   "",
+			},
+			[]string{
+				"initrd=initrd",
+				"root=nfs:example/path/to/rootfs:ro",
+				"xname=x0000c0s0b0n0",
+				"nid=0",
+				fmt.Sprintf("ds=nocloud-net;s=%s/", advertiseAddress),
+			},
+		},
+		{
+			// Existing BOOTIF in params is preserved (not overwritten)
+			BootData{
+				Params: "root=nfs:example/path/to/rootfs:ro BOOTIF=01-11-22-33-44-55-66",
+				Kernel: ImageData{Path: "http://example/path/to/vmlinuz"},
+				Initrd: ImageData{Path: "http://example/path/to/initramfs.img"},
+			},
+			scriptParams{
+				xname: "x0000c0s0b0n0",
+				nid:   "0",
+				mac:   "aa:bb:cc:dd:ee:ff",
+			},
+			[]string{
+				"initrd=initrd",
+				"root=nfs:example/path/to/rootfs:ro",
+				"BOOTIF=01-11-22-33-44-55-66",
+				"xname=x0000c0s0b0n0",
+				"nid=0",
+				fmt.Sprintf("ds=nocloud-net;s=%s/", advertiseAddress),
+			},
+		},
+		{
+			// BOOTIF with uppercase MAC address
+			BootData{
+				Params: "root=nfs:example/path/to/rootfs:ro",
+				Kernel: ImageData{Path: "http://example/path/to/vmlinuz"},
+				Initrd: ImageData{Path: "http://example/path/to/initramfs.img"},
+			},
+			scriptParams{
+				xname: "x0000c0s0b0n0",
+				nid:   "0",
+				mac:   "AA:BB:CC:DD:EE:FF",
+			},
+			[]string{
+				"initrd=initrd",
+				"root=nfs:example/path/to/rootfs:ro",
+				"xname=x0000c0s0b0n0",
+				"nid=0",
+				"BOOTIF=01-AA-BB-CC-DD-EE-FF",
+				fmt.Sprintf("ds=nocloud-net;s=%s/", advertiseAddress),
+			},
+		},
+		{
+			// BOOTIF with all parameters (mac, referralToken, kernel params)
+			BootData{
+				Params: "root=nfs:example/path/to/rootfs:ro",
+				Kernel: ImageData{Path: "http://example/path/to/vmlinuz", Params: "console=ttyS0"},
+				Initrd: ImageData{Path: "http://example/path/to/initramfs.img"},
+			},
+			scriptParams{
+				xname:         "x0000c0s0b0n0",
+				nid:           "0",
+				referralToken: "test_token",
+				mac:           "00:11:22:33:44:55",
+			},
+			[]string{
+				"initrd=initrd",
+				"root=nfs:example/path/to/rootfs:ro",
+				"console=ttyS0",
+				"xname=x0000c0s0b0n0",
+				"nid=0",
+				"bss_referral_token=test_token",
+				"BOOTIF=01-00-11-22-33-44-55",
+				fmt.Sprintf("ds=nocloud-net;s=%s/", advertiseAddress),
+			},
+		},
 	}
 
 	for _, tc := range test_cases {


### PR DESCRIPTION
### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [ ] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [ ] **REUSE Compliance**:  
  - [ ] Each new/modified source file has SPDX copyright and license headers  
  - [ ] Any non-commentable files include a `<filename>.license` sidecar  
  - [ ] All referenced licenses are present in the `LICENSES/` directory  

### Description


On multi-NIC servers booted via BSS, dracut receives `ip=dhcp` with no `BOOTIF` parameter. It sends DHCP on all interfaces and configures whichever responds first, which may not be the PXE boot NIC. This breaks cloud-init (wrong IP) and network configuration at boot time. BSS currently leaves it to admins to hardcode BOOTIF at the boot layer in stored params, which is error-prone and difficult to do generically for a group.

### Fix

`buildParams()` already injects `xname=`, `nid=`, and `ds=` dynamically at serve time using `checkParam()`. This PR adds BOOTIF to that list.

The requesting MAC is available in `BootscriptGet()` from `?mac=<mac>`. It's threaded into `scriptParams` and injected as `BOOTIF=01-<mac>` in `buildParams()`.

### Behavior

- Single-NIC nodes: BOOTIF is harmless, dracut confirms the only interface
- Multi-NIC nodes: dracut correctly identifies the PXE boot interface  
- Operators with explicit BOOTIF in stored params: `checkParam()` skips
  injection, no duplicate, no override
- Nodes fetched by `?name=` or `?nid=` without MAC: no injection (safe guard)

### How to use this:

~~~
# you can now set this explicitly per node in stored params
ochami bss boot params set -d '{
  "macs": ["aa:bb:cc:dd:ee:ff"],
  "params": "ip=dhcp bond=bond0:eno1,eno2:mode=1,miimon=100 ip=bond0:dhcp"
}'
~~~


Fixes #(issue)  did not open issue.

### Type of Change

- [ ] Bug fix  
- [x] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
