### PR TITLE
fix bug#70 - update boot params fails when MAC is not in lower case

### DIFF
--- a/internal/postgres/bootparams.go
+++ b/internal/postgres/bootparams.go
@@ -265,7 +265,7 @@ func (bddb BootDataDatabase) CheckNodeExistence(macs, xnames []string, nids []in
 
 	// Iterate through each slice of mac/xname/nid and categorize each's existence.
 	for _, m := range macs {
-		if _, ok := macToNode[m]; !ok {
+		if _, ok := macToNode[strings.ToLower(m)]; !ok {
 			nonExistingMacs = append(nonExistingMacs, m)
 		}
 	}
@@ -525,7 +525,12 @@ func (bddb BootDataDatabase) getNodesWithConfigs(macs, xnames []string, nids []i
 				}
 				switch i {
 				case 0:
-					qstr += fmt.Sprintf(` boot_mac IN %s`, stringSliceToSql(macs))
+					// Ignore case when searching by MAC.
+					var macsLower []string
+					for _, mac := range macs {
+						macsLower = append(macsLower, strings.ToLower(mac))
+					}
+					qstr += fmt.Sprintf(` boot_mac IN %s`, stringSliceToSql(macsLower))
 				case 1:
 					qstr += fmt.Sprintf(` xname IN %s`, stringSliceToSql(xnames))
 				case 2:


### PR DESCRIPTION
## Pull Request Template

Thank you for your contribution! Please ensure the following before submitting:

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [ ] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [ ] **REUSE Compliance**:  
  - [ ] Each new/modified source file has SPDX copyright and license headers  
  - [ ] Any non-commentable files include a `<filename>.license` sidecar  
  - [ ] All referenced licenses are present in the `LICENSES/` directory  

### Description

MAC addresses in BSS are usually converted to all lower-case. That didn't happen in the update boot params function and when looking up existing entries in the DB. This PR fixes it.

Fixes #70 

### Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
